### PR TITLE
Add very basic Dockerfile to build Docker container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .dockerignore
 .git
+Dockerfile
 LICENSE
 README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+LICENSE
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .dockerignore
+.git
 LICENSE
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM lipanski/docker-static-website:latest
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["/busybox-httpd", "-f", "-v", "-p", "3000", "-c", "httpd.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM lipanski/docker-static-website:latest
 
-COPY . .
+COPY Dashboard.html index.html
+
+COPY system-resources.html system-resources.html
 
 EXPOSE 3000
 


### PR DESCRIPTION
Hey there!

Here is very very basic PR that adds a `.dockerignore` file and a `Dockerfile` which can be used to build a Docker container image with a simple busybox webserver for your dashboard.

If you cannot build the image yourself, you can look into using Github actions to have it built automatically for you.

The base image being used is this: https://github.com/lipanski/docker-static-website

For simplicity, the build is copying your `Dashboard.html` file as `index.html` into the image.

The image can then be run like this: `docker run --rm --name dashboard -d -p 3333:3000 repo/image:tag`

And the webserver should then be reachable at `http://localhost:3333`

In order for users to customize the dashboard, they need to mount the two files to their Docker host. Ideally a Docker Compose file is used, like this as example:

```
services:
  dashboard:
    image: repo/image:tag
    ports:
      - 3333:3000
    volumes:
      - ./dashboard.html:/home/static/index.html
      - ./system-resources.html:/home/static/system-resources.html
```

This would mount the two existing files in the current directory from the host into the image at `/home/static` from where the webserver is serving them.

I would suggest you change your `Dashboard.html` into `dashboard.html` for the future, as this might trip up a lot of users and lowercase filenames are the common norm.

Note: Using this very lightweight busybox webserver has some small but important downsides. It will behave a little differently to common Docker images. If you are willing to increase the image size and possibly CPU/memory workload by just a bit, then using `nginx` as webserver and base image is more common and in my opinion worth it. But since your dashboard itself is already so tiny and light on resources, i thought it may suit you to also have a Docker image in the same spirit. If you prefer a nginx Dockerfile for this, i think i can do a PR for that too.